### PR TITLE
fix-for-long-description-pypi-syntax-error

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1051,7 +1051,7 @@
                 "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
                 "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '3.8'",
             "version": "==6.8.0"
         },
         "isort": {

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Arguments
   "Regulatory frameworks to take into account", "`--frameworks`", "`AZURE_LABELER_FRAMEWORKS`", "`'Microsoft cloud security benchmark,Azure CIS 1.1.0'`"
   "Explicit list of subscriptions to take into account", "`--allowed-subscription-ids`", "`AZURE_LABELER_ALLOWED_SUBSCRIPTION_IDS`", "`'00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001'`"
   "Explicit list of subscriptions NOT to take into account", "`--denied-subscription-ids`", "`AZURE_LABELER_DENIED_SUBSCRIPTION_IDS`", "`'00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001'`"
-  "List of resource groups to exclude", "`--denied-resource-group-names`", "`AZURE_LABELER_DENIED_RESOURCE_GROUP_NAMES`", "`["SBPP-WEU-AARC-01-RSG", "SBPA-WEU-AARC-01-RSG"]`"
+  "List of resource groups to exclude", "`--denied-resource-group-names`", "`AZURE_LABELER_DENIED_RESOURCE_GROUP_NAMES`", "`'SBPP-WEU-AARC-01-RSG, SBPA-WEU-AARC-01-RSG'`"
   "Level of log printing", "`--log-level`", "`AZURE_LABELER_LOG_LEVEL`", "`info`"
   "Logging configuration", "`--log-config`", "`AZURE_LABELER_LOG_CONFIG`", ""
 

--- a/azureenergylabelercli/azureenergylabelercli.py
+++ b/azureenergylabelercli/azureenergylabelercli.py
@@ -148,7 +148,7 @@ def get_arguments():
                                    default=os.environ.get('AZURE_LABELER_DENIED_RESOURCE_GROUP_NAMES'),
                                    type=comma_delimited_list,
                                    help=('A comma delimited list of Azure resource group names that will '
-                                         'be excluded from producing the energy label.'
+                                         'be excluded from producing the energy label.\n'
                                          'example='
                                          '"SBPP-WEU-AARC-01-RSG, SBPA-WEU-AARC-01-RSG"'))
     parser.add_argument('--export-path',


### PR DESCRIPTION
fix: the list syntax in the readme file broke the release. It expects a comma after a quote.